### PR TITLE
fix for "falsefalse" value in 15.5 triple sec k2

### DIFF
--- a/wiki/equipment.json
+++ b/wiki/equipment.json
@@ -3648,7 +3648,7 @@
     "_buildable": false,
     "_evasion": 1,
     "_firepower": 9,
-    "_flight_cost": "falsefalse",
+    "_flight_cost": false,
     "_flight_range": false,
     "_icon": 4,
     "_id": 463,


### PR DESCRIPTION
_flight_cost value for 15.5cm Triple Secondary Gun Mount Kai Ni has the string value "falsefalse" rather than the boolean false.